### PR TITLE
refactor: Shorten test definitions to better show wrapper usage

### DIFF
--- a/src/test/pactwith.supertest.test.ts
+++ b/src/test/pactwith.supertest.test.ts
@@ -19,16 +19,13 @@ const postValidRequest: InteractionObject = {
 
 pactWithSuperTest(
   { consumer: "MyConsumer", provider: "pactWithSuperTest", port: pactPort },
-  async (pactMock: Pact, client: supertest.SuperTest<supertest.Test>) => {
-    test("should accept a valid get request to get a pet", async () => {
-      await pactMock.addInteraction(postValidRequest);
+  (pactMock: Pact, client: supertest.SuperTest<supertest.Test>) => {
+    beforeEach(() => pactMock.addInteraction(postValidRequest));
 
-      await client
+    test("should accept a valid get request to get a pet", () =>
+      client
         .get("/v2/pet/1")
         .set("api_key", "[]")
-        .expect(200);
-
-      await pactMock.verify();
-    });
+        .expect(200));
   }
 );

--- a/src/test/pactwith.test.ts
+++ b/src/test/pactwith.test.ts
@@ -24,34 +24,23 @@ const postValidRequest: InteractionObject = {
 
 pactWith(
   { consumer: "MyConsumer", provider: "pactWith", port: pactPort },
-  async (provider: any) => {
-    test("should be be able to hide the pact stuff behind the scenes with a port of the users choosing", async () => {
-      await provider.addInteraction(postValidRequest);
-      const client = getClient(pactPort);
+  (provider: any) => {
+    beforeEach(() => provider.addInteraction(postValidRequest));
 
-      await client
+    test("should be be able to hide the pact stuff behind the scenes with a port of the users choosing", () =>
+      getClient(pactPort)
         .get("/v2/pet/1845563262948980200")
         .set("api_key", "[]")
-        .expect(200);
-
-      await provider.verify();
-    });
+        .expect(200));
   }
 );
 
-pactWith(
-  { consumer: "MyConsumer", provider: "pactWith2" },
-  async (provider: any) => {
-    test("should be ok if i dont provide a port", async () => {
-      await provider.addInteraction(postValidRequest);
-      const client = getClient(8282);
+pactWith({ consumer: "MyConsumer", provider: "pactWith2" }, (provider: any) => {
+  beforeEach(() => provider.addInteraction(postValidRequest));
 
-      await client
-        .get("/v2/pet/1845563262948980200")
-        .set("api_key", "[]")
-        .expect(200);
-
-      await provider.verify();
-    });
-  }
-);
+  test("should be ok if i dont provide a port", () =>
+    getClient(8282)
+      .get("/v2/pet/1845563262948980200")
+      .set("api_key", "[]")
+      .expect(200));
+});

--- a/src/test/pactwith.test.ts
+++ b/src/test/pactwith.test.ts
@@ -3,6 +3,7 @@ import * as supertest from "supertest";
 import { pactWith } from "../index";
 
 const getClient = (provider: any) => supertest(provider.mockService.baseUrl);
+const pactPort: number = 5001;
 
 const postValidRequest: InteractionObject = {
   state: "A pet 1845563262948980200 exists",
@@ -18,24 +19,42 @@ const postValidRequest: InteractionObject = {
 };
 
 pactWith(
-  { consumer: "MyConsumer", provider: "pactWith", port: 5001 },
+  { consumer: "MyConsumer", provider: "pactWith", port: pactPort },
   (provider: any) => {
-    beforeEach(() => provider.addInteraction(postValidRequest));
+    describe("pact integration", () => {
+      beforeEach(() => provider.addInteraction(postValidRequest));
 
-    test("should be be able to hide the pact stuff behind the scenes with a port of the users choosing", () =>
-      getClient(provider)
-        .get("/v2/pet/1845563262948980200")
-        .set("api_key", "[]")
-        .expect(200));
+      test("should be be able to hide the pact stuff behind the scenes with a port of the users choosing", () =>
+        getClient(provider)
+          .get("/v2/pet/1845563262948980200")
+          .set("api_key", "[]")
+          .expect(200));
+    });
+
+    describe("provider object", () => {
+      test("should show the specified port in the URL", () => {
+        expect(provider.mockService.baseUrl).toMatch(
+          new RegExp(`${pactPort}$`)
+        );
+      });
+    });
   }
 );
 
 pactWith({ consumer: "MyConsumer", provider: "pactWith2" }, (provider: any) => {
-  beforeEach(() => provider.addInteraction(postValidRequest));
+  describe("pact integration", () => {
+    beforeEach(() => provider.addInteraction(postValidRequest));
 
-  test("should be ok if i dont provide a port", () =>
-    getClient(provider)
-      .get("/v2/pet/1845563262948980200")
-      .set("api_key", "[]")
-      .expect(200));
+    test("should be ok if i dont provide a port", () =>
+      getClient(provider)
+        .get("/v2/pet/1845563262948980200")
+        .set("api_key", "[]")
+        .expect(200));
+  });
+
+  describe("provider object", () => {
+    test("should show the default port in the URL", () => {
+      expect(provider.mockService.baseUrl).toMatch(new RegExp(`8282$`));
+    });
+  });
 });

--- a/src/test/pactwith.test.ts
+++ b/src/test/pactwith.test.ts
@@ -2,12 +2,7 @@ import { InteractionObject } from "@pact-foundation/pact";
 import * as supertest from "supertest";
 import { pactWith } from "../index";
 
-const pactPort: number = 5001;
-
-const getClient = (port: number) => {
-  const url = `http://localhost:${port}`;
-  return supertest(url);
-};
+const getClient = (provider: any) => supertest(provider.mockService.baseUrl);
 
 const postValidRequest: InteractionObject = {
   state: "A pet 1845563262948980200 exists",
@@ -23,12 +18,12 @@ const postValidRequest: InteractionObject = {
 };
 
 pactWith(
-  { consumer: "MyConsumer", provider: "pactWith", port: pactPort },
+  { consumer: "MyConsumer", provider: "pactWith", port: 5001 },
   (provider: any) => {
     beforeEach(() => provider.addInteraction(postValidRequest));
 
     test("should be be able to hide the pact stuff behind the scenes with a port of the users choosing", () =>
-      getClient(pactPort)
+      getClient(provider)
         .get("/v2/pet/1845563262948980200")
         .set("api_key", "[]")
         .expect(200));
@@ -39,7 +34,7 @@ pactWith({ consumer: "MyConsumer", provider: "pactWith2" }, (provider: any) => {
   beforeEach(() => provider.addInteraction(postValidRequest));
 
   test("should be ok if i dont provide a port", () =>
-    getClient(8282)
+    getClient(provider)
       .get("/v2/pet/1845563262948980200")
       .set("api_key", "[]")
       .expect(200));


### PR DESCRIPTION
I noticed the wrapper wasn't being used as I'd intended it, so I changed the test definitions to better match the intended use (significantly shorter code, with no need for async/await). Let me know what you think.