### PR TITLE
feat: use random ports for provider, if not provided

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export declare type LogLevel =
 export declare type PactFileWriteMode = "overwrite" | "update" | "merge";
 
 const applyDefaults = (options: PactOptions) => ({
-  port: options.port || 8282,
+  port: options.port,
   log: path.resolve(
     process.cwd(),
     "pact/logs",

--- a/src/test/pactwith.test.ts
+++ b/src/test/pactwith.test.ts
@@ -53,8 +53,8 @@ pactWith({ consumer: "MyConsumer", provider: "pactWith2" }, (provider: any) => {
   });
 
   describe("provider object", () => {
-    test("should show the default port in the URL", () => {
-      expect(provider.mockService.baseUrl).toMatch(new RegExp(`8282$`));
+    test("should show the randomly assigned port in the URL", () => {
+      expect(provider.mockService.baseUrl).toMatch(new RegExp(`\\d{4,5}$`));
     });
   });
 });


### PR DESCRIPTION
- [X] Remove default port, allow `pact-js` to set a random port, and expose this to the client
