### PR TITLE
chore: add .versionrc to pick up renovate chore(deps) changes

### DIFF
--- a/.versionrc
+++ b/.versionrc
@@ -1,0 +1,33 @@
+{
+    "types": [
+        {
+            "type": "feat",
+            "section": "Features"
+        },
+        {
+            "type": "fix",
+            "section": "Bug Fixes"
+        },
+        {
+            "type": "chore",
+            "section": "Dependencies",
+            "scope": "deps"
+        },
+        {
+            "type": "style",
+            "hidden": true
+        },
+        {
+            "type": "refactor",
+            "hidden": true
+        },
+        {
+            "type": "perf",
+            "hidden": true
+        },
+        {
+            "type": "test",
+            "hidden": true
+        }
+    ]
+}


### PR DESCRIPTION
Renovate creates dependency pull requests with `chore(deps)` but this scope isn't picked up by standard-version which we use for release.

This will resolve it and put the dep updates under a `Dependencies` section in the changelog